### PR TITLE
Release v0.0.4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,57 @@
+run:
+  timeout: 5m
+  tests: false
+
+linters-settings:
+  lll:
+    line-length: 120
+    tab-width: 1
+    ignore-strings: true
+
+issues:
+  exclude-rules:
+    - path: _test\.go$
+      linters:
+        - all
+    - linters:
+        - lll
+      source: "^//"
+
+linters:
+  enable:
+    - gofmt
+    - revive
+    - govet
+    - errcheck
+    - staticcheck
+    - gosec
+    - prealloc
+    - unconvert
+    - gocritic
+    - unused
+    - ineffassign
+    - typecheck
+    - gosimple
+    - gocyclo
+    - dupl
+    - misspell
+    - unparam
+    - nakedret
+    - lll
+    - gochecknoinits
+    - gochecknoglobals
+    - goconst
+    - gocognit
+    - mnd
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - stylecheck
+    - thelper
+    - tparallel
+    - whitespace
+    - wrapcheck
+    - wsl

--- a/client.go
+++ b/client.go
@@ -10,20 +10,30 @@ type HttpClient struct {
 	requestOptions *RequestOptions
 }
 
+// NewHttpClient creates a new HttpClient with default settings.
+// Default settings are:
+// - Timeout: 20 seconds
+// - BodyMarshaler: NoopBodyMarshaler - this marshaler does not modify the request body. Allows to create requests by passing the same type as the standard http.NewRequestWithContext accepts with some additions for convenience (see NewNoopBodyMarshaler).
+// - BodyUnmarshaler: NoopBodyUnmarshaler - this unmarshaler does not modify the response body, just writes it to the destination with some added handling for convenience (see NewNoopBodyUnmarshaler).
 func NewHttpClient() *HttpClient {
 	return &HttpClient{
 		client: &http.Client{
 			Timeout: time.Second * 20,
 		},
 		requestOptions: &RequestOptions{
-			BodyMarshaler: NewNoopBodyMarshaler(),
+			BodyMarshaler:   NewNoopBodyMarshaler(),
+			BodyUnmarshaler: NewNoopBodyUnmarshaler(),
 		},
 	}
 }
 
+// Clone creates a new HttpClient with the same settings as the original one.
+// The cloned client can be modified independently without affecting the original client.
 func (c *HttpClient) Clone() *HttpClient {
 	clone := &HttpClient{
-		client:         c.client,
+		client: &http.Client{
+			Timeout: c.client.Timeout,
+		},
 		requestOptions: c.requestOptions.Clone(),
 	}
 	return clone
@@ -33,46 +43,69 @@ func (c *HttpClient) do(req *http.Request) (*http.Response, error) {
 	return c.client.Do(req)
 }
 
+// SetBodyMarshaler sets the BodyMarshaler at the HttpClient level.
+// This will affect all requests made with this client unless overridden at the request level.
 func (c *HttpClient) SetBodyMarshaler(marshaler BodyMarshaler) *HttpClient {
 	c.requestOptions.SetBodyMarshaler(marshaler)
 	return c
 }
 
+// SetBodyUnmarshaler sets the BodyUnmarshaler at the HttpClient level.
+// This will affect all requests made with this client unless overridden at the request level.
 func (c *HttpClient) SetBodyUnmarshaler(unmarshaler BodyUnmarshaler) *HttpClient {
 	c.requestOptions.SetBodyUnmarshaler(unmarshaler)
 	return c
 }
 
+// SetHeaders sets the headers at the HttpClient level.
+// Headers will affect all requests made with this client.
+// When headers are set at the request level, they will be merged with the ones set at the client level.
+// Headers set at the request level will override the ones set at the client level for that specific request.
 func (c *HttpClient) SetHeaders(headers map[string]string) *HttpClient {
 	c.requestOptions.SetHeaders(headers)
 	return c
 }
 
+// SetHeader sets a single header at the HttpClient level.
+// Headers merging and override precedence is the same as with SetHeaders.
 func (c *HttpClient) SetHeader(key, value string) *HttpClient {
 	c.requestOptions.SetHeader(key, value)
 	return c
 }
 
+// SetTimeout sets the timeout for the underlying http.Client.
+// This timeout will apply to all requests made with this client.
 func (c *HttpClient) SetTimeout(timeout time.Duration) *HttpClient {
 	c.client.Timeout = timeout
 	return c
 }
 
+// SetOnRequestReady sets a hook that will be called right after an http.Request is created and all headers and body are set.
+// This hook will be called for all requests made with this client unless overridden at the request level.
 func (c *HttpClient) SetOnRequestReady(onRequestReady OnRequestReadyHook) *HttpClient {
 	c.requestOptions.SetOnRequestReady(onRequestReady)
 	return c
 }
 
+// SetOnResponseReady sets a hook that will be called right after the response is received and before it is processed.
+// This hook will be called for all requests made with this client unless overridden at the request level.
 func (c *HttpClient) SetOnResponseReady(onResponseReady OnResponseReadyHook) *HttpClient {
 	c.requestOptions.SetOnResponseReady(onResponseReady)
 	return c
 }
 
+// SetDumpOnError configures logging of the request, response and error when an error occurs.
+// http.Request and http.Response bodies will be logged as well, if they are set.
+// Original body passed by the caller code will be logged as well, if it is set.
+// This method will also enable the StackTraceEnabled option, which will add a stack trace to the error if it occurs.
+// This will affect all requests made with this client unless overridden at the request level.
 func (c *HttpClient) SetDumpOnError() *HttpClient {
 	c.requestOptions.SetDumpOnError()
 	return c
 }
 
+// SetStackTraceEnabled enables or disables the stack trace in the error if it occurs.
+// This will affect all requests made with this client unless overridden at the request level.
 func (c *HttpClient) SetStackTraceEnabled(enabled bool) *HttpClient {
 	c.requestOptions.SetStackTraceEnabled(enabled)
 	return c

--- a/client.go
+++ b/client.go
@@ -36,6 +36,7 @@ func (c *HttpClient) Clone() *HttpClient {
 		},
 		requestOptions: c.requestOptions.Clone(),
 	}
+
 	return clone
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,1052 @@
+package httpreqx
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHttpClient(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("NewHttpClient", func(t *testing.T) {
+		client := NewHttpClient()
+		r.NotNil(client)
+		r.NotNil(client.client)
+		r.Equal(20*time.Second, client.client.Timeout)
+		r.NotNil(client.requestOptions)
+		r.NotNil(client.requestOptions.BodyMarshaler)
+		r.NotNil(client.requestOptions.BodyUnmarshaler)
+	})
+
+	t.Run("Clone", func(t *testing.T) {
+		original := NewHttpClient().
+			SetTimeout(30*time.Second).
+			SetHeader("Authorization", "Bearer token").
+			SetBodyMarshaler(NewJSONBodyMarshaler()).
+			SetBodyUnmarshaler(NewJSONBodyUnmarshaler())
+
+		clone := original.Clone()
+		r.NotNil(clone)
+		r.NotEqual(original, clone)
+		r.Equal(original.client.Timeout, clone.client.Timeout)
+		r.Equal(original.requestOptions.Headers, clone.requestOptions.Headers)
+		r.Equal(original.requestOptions.BodyMarshaler, clone.requestOptions.BodyMarshaler)
+		r.Equal(original.requestOptions.BodyUnmarshaler, clone.requestOptions.BodyUnmarshaler)
+
+		// Verify independence
+		clone.SetTimeout(10 * time.Second)
+		r.Equal(10*time.Second, clone.client.Timeout)
+		r.Equal(30*time.Second, original.client.Timeout)
+	})
+
+	t.Run("SetTimeout", func(t *testing.T) {
+		client := NewHttpClient()
+		timeout := 15 * time.Second
+		client.SetTimeout(timeout)
+		r.Equal(timeout, client.client.Timeout)
+	})
+
+	t.Run("SetHeader", func(t *testing.T) {
+		client := NewHttpClient()
+		client.SetHeader("Authorization", "Bearer token123")
+		r.Equal("Bearer token123", client.requestOptions.Headers["Authorization"])
+	})
+
+	t.Run("SetHeaders", func(t *testing.T) {
+		client := NewHttpClient()
+		headers := map[string]string{
+			"Authorization": "Bearer token123",
+			"User-Agent":    "TestClient/1.0",
+			"Accept":        "application/json",
+		}
+		client.SetHeaders(headers)
+		r.Equal(headers, client.requestOptions.Headers)
+	})
+
+	t.Run("SetBodyMarshaler", func(t *testing.T) {
+		client := NewHttpClient()
+		jsonMarshaler := NewJSONBodyMarshaler()
+		client.SetBodyMarshaler(jsonMarshaler)
+		r.Equal(jsonMarshaler, client.requestOptions.BodyMarshaler)
+	})
+
+	t.Run("SetBodyUnmarshaler", func(t *testing.T) {
+		client := NewHttpClient()
+		jsonUnmarshaler := NewJSONBodyUnmarshaler()
+		client.SetBodyUnmarshaler(jsonUnmarshaler)
+		r.Equal(jsonUnmarshaler, client.requestOptions.BodyUnmarshaler)
+	})
+
+	t.Run("SetOnRequestReady", func(t *testing.T) {
+		client := NewHttpClient()
+		hook := func(req *http.Request) error {
+			return nil
+		}
+		client.SetOnRequestReady(hook)
+		r.NotNil(client.requestOptions.OnRequestReady)
+	})
+
+	t.Run("SetOnResponseReady", func(t *testing.T) {
+		client := NewHttpClient()
+		hook := func(resp *http.Response) error {
+			return nil
+		}
+		client.SetOnResponseReady(hook)
+		r.NotNil(client.requestOptions.OnResponseReady)
+	})
+
+	t.Run("SetDumpOnError", func(t *testing.T) {
+		client := NewHttpClient()
+		client.SetDumpOnError()
+		r.True(client.requestOptions.StackTraceEnabled)
+		r.Len(client.requestOptions.OnErrorHooks, 1)
+	})
+
+	t.Run("SetStackTraceEnabled", func(t *testing.T) {
+		client := NewHttpClient()
+		client.SetStackTraceEnabled(true)
+		r.True(client.requestOptions.StackTraceEnabled)
+
+		client.SetStackTraceEnabled(false)
+		r.False(client.requestOptions.StackTraceEnabled)
+	})
+}
+
+func TestRequest(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("NewRequest", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+		body := map[string]string{"key": "value"}
+
+		req := client.NewRequest(ctx, http.MethodPost, "/test", body)
+		r.NotNil(req)
+		r.Equal(client, req.client)
+		r.Equal(http.MethodPost, req.method)
+		r.Equal("/test", req.path)
+		r.Equal(ctx, req.ctx)
+		r.Equal(body, req.body)
+		r.Equal(client.requestOptions, req.options)
+	})
+
+	t.Run("HTTP Method Requests", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+
+		testCases := []struct {
+			name    string
+			method  string
+			path    string
+			body    interface{}
+			creator func() *Request
+		}{
+			{
+				name:   "GET",
+				method: http.MethodGet,
+				path:   "/get",
+				body:   nil,
+				creator: func() *Request {
+					return client.NewGetRequest(ctx, "/get")
+				},
+			},
+			{
+				name:   "POST",
+				method: http.MethodPost,
+				path:   "/post",
+				body:   "test body",
+				creator: func() *Request {
+					return client.NewPostRequest(ctx, "/post", "test body")
+				},
+			},
+			{
+				name:   "PUT",
+				method: http.MethodPut,
+				path:   "/put",
+				body:   "test body",
+				creator: func() *Request {
+					return client.NewPutRequest(ctx, "/put", "test body")
+				},
+			},
+			{
+				name:   "PATCH",
+				method: http.MethodPatch,
+				path:   "/patch",
+				body:   "test body",
+				creator: func() *Request {
+					return client.NewPatchRequest(ctx, "/patch", "test body")
+				},
+			},
+			{
+				name:   "DELETE",
+				method: http.MethodDelete,
+				path:   "/delete",
+				body:   nil,
+				creator: func() *Request {
+					return client.NewDeleteRequest(ctx, "/delete")
+				},
+			},
+			{
+				name:   "OPTIONS",
+				method: http.MethodOptions,
+				path:   "/options",
+				body:   nil,
+				creator: func() *Request {
+					return client.NewOptionsRequest(ctx, "/options")
+				},
+			},
+			{
+				name:   "CONNECT",
+				method: http.MethodConnect,
+				path:   "/connect",
+				body:   nil,
+				creator: func() *Request {
+					return client.NewConnectRequest(ctx, "/connect")
+				},
+			},
+			{
+				name:   "HEAD",
+				method: http.MethodHead,
+				path:   "/head",
+				body:   nil,
+				creator: func() *Request {
+					return client.NewHeadRequest(ctx, "/head")
+				},
+			},
+			{
+				name:   "TRACE",
+				method: http.MethodTrace,
+				path:   "/trace",
+				body:   nil,
+				creator: func() *Request {
+					return client.NewTraceRequest(ctx, "/trace")
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				req := tc.creator()
+				r.Equal(tc.method, req.method)
+				r.Equal(tc.path, req.path)
+				r.Equal(tc.body, req.body)
+			})
+		}
+	})
+
+	t.Run("WriteBodyTo", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+		req := client.NewGetRequest(ctx, "/test")
+
+		var result string
+		req.WriteBodyTo(&result)
+		r.True(req.unmarshalResult)
+		r.Equal(&result, req.unmarshalResultTo)
+	})
+
+	t.Run("SetBodyMarshaler", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+		req := client.NewPostRequest(ctx, "/test", "body")
+
+		jsonMarshaler := NewJSONBodyMarshaler()
+		req.SetBodyMarshaler(jsonMarshaler)
+		r.Equal(jsonMarshaler, req.options.BodyMarshaler)
+	})
+
+	t.Run("SetBodyUnmarshaler", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+		req := client.NewGetRequest(ctx, "/test")
+
+		jsonUnmarshaler := NewJSONBodyUnmarshaler()
+		req.SetBodyUnmarshaler(jsonUnmarshaler)
+		r.Equal(jsonUnmarshaler, req.options.BodyUnmarshaler)
+	})
+
+	t.Run("SetHeader", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+		req := client.NewGetRequest(ctx, "/test")
+
+		req.SetHeader("X-Test", "test-value")
+		r.Equal("test-value", req.options.Headers["X-Test"])
+	})
+
+	t.Run("SetHeaders", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+		req := client.NewGetRequest(ctx, "/test")
+
+		headers := map[string]string{
+			"X-Test1": "value1",
+			"X-Test2": "value2",
+		}
+		req.SetHeaders(headers)
+		r.Equal(headers, req.options.Headers)
+	})
+
+	t.Run("SetOnRequestReady", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+		req := client.NewGetRequest(ctx, "/test")
+
+		hook := func(req *http.Request) error {
+			return nil
+		}
+		req.SetOnRequestReady(hook)
+		r.NotNil(req.options.OnRequestReady)
+	})
+
+	t.Run("SetOnResponseReady", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+		req := client.NewGetRequest(ctx, "/test")
+
+		hook := func(resp *http.Response) error {
+			return nil
+		}
+		req.SetOnResponseReady(hook)
+		r.NotNil(req.options.OnResponseReady)
+	})
+
+	t.Run("SetDumpOnError", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+		req := client.NewGetRequest(ctx, "/test")
+
+		req.SetDumpOnError()
+		r.True(req.options.StackTraceEnabled)
+		r.Len(req.options.OnErrorHooks, 1)
+	})
+
+	t.Run("SetStackTraceEnabled", func(t *testing.T) {
+		client := NewHttpClient()
+		ctx := context.Background()
+		req := client.NewGetRequest(ctx, "/test")
+
+		req.SetStackTraceEnabled(true)
+		r.True(req.options.StackTraceEnabled)
+
+		req.SetStackTraceEnabled(false)
+		r.False(req.options.StackTraceEnabled)
+	})
+}
+
+func TestRequestExecution(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Successful GET Request", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/success":
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"status": "success", "message": "Hello World"}`))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient()
+		ctx := context.Background()
+
+		var result string
+		resp, err := client.NewGetRequest(ctx, server.URL+"/success").
+			WriteBodyTo(&result).
+			Do()
+
+		r.NoError(err)
+		r.NotNil(resp)
+		r.Equal(http.StatusOK, resp.StatusCode)
+		r.Contains(result, "success")
+		r.Contains(result, "Hello World")
+	})
+
+	t.Run("Successful POST Request with JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/post":
+				if r.Method != http.MethodPost {
+					w.WriteHeader(http.StatusMethodNotAllowed)
+					return
+				}
+				if r.Header.Get("Content-Type") != "application/json" {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
+				var requestBody map[string]interface{}
+				if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
+				response := map[string]interface{}{
+					"received": requestBody,
+					"status":   "success",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(response)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient().
+			SetBodyMarshaler(NewJSONBodyMarshaler()).
+			SetBodyUnmarshaler(NewJSONBodyUnmarshaler())
+
+		ctx := context.Background()
+		requestBody := map[string]interface{}{
+			"name":  "John Doe",
+			"email": "john@example.com",
+		}
+
+		var result map[string]interface{}
+		resp, err := client.NewPostRequest(ctx, server.URL+"/post", requestBody).
+			WriteBodyTo(&result).
+			Do()
+
+		r.NoError(err)
+		r.NotNil(resp)
+		r.Equal(http.StatusOK, resp.StatusCode)
+		r.Equal("success", result["status"])
+		r.Equal(requestBody, result["received"])
+	})
+
+	t.Run("Request with Custom Headers", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/headers":
+				response := map[string]string{
+					"authorization": r.Header.Get("Authorization"),
+					"user-agent":    r.Header.Get("User-Agent"),
+					"x-custom":      r.Header.Get("X-Custom"),
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(response)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient().
+			SetHeader("Authorization", "Bearer client-token").
+			SetHeader("User-Agent", "TestClient/1.0")
+
+		ctx := context.Background()
+
+		var result string
+		resp, err := client.NewGetRequest(ctx, server.URL+"/headers").
+			SetHeader("X-Custom", "request-header").
+			WriteBodyTo(&result).
+			Do()
+
+		r.NoError(err)
+		r.NotNil(resp)
+		r.Equal(http.StatusOK, resp.StatusCode)
+		r.Contains(result, "Bearer client-token")
+		r.Contains(result, "TestClient/1.0")
+		r.Contains(result, "request-header")
+	})
+
+	t.Run("Request with Hooks", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/hooks":
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"status": "success"}`))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient().
+			SetOnRequestReady(func(req *http.Request) error {
+				req.Header.Set("X-Request-Hook", "called")
+				return nil
+			}).
+			SetOnResponseReady(func(resp *http.Response) error {
+				return nil
+			})
+
+		ctx := context.Background()
+
+		resp, err := client.NewGetRequest(ctx, server.URL+"/hooks").Do()
+
+		r.NoError(err)
+		r.NotNil(resp)
+		r.Equal(http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("Request with NoopBodyMarshaler", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/noop":
+				body, _ := json.Marshal(map[string]string{
+					"received_body": r.Header.Get("X-Body-Length"),
+				})
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(body)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient().
+			SetBodyUnmarshaler(NewJSONBodyUnmarshaler())
+
+		ctx := context.Background()
+
+		testCases := []struct {
+			name     string
+			body     interface{}
+			expected string
+		}{
+			{
+				name:     "String Body",
+				body:     "test string body",
+				expected: "16",
+			},
+			{
+				name:     "Byte Slice Body",
+				body:     []byte("test byte body"),
+				expected: "14",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				var result map[string]string
+				var bodyLength int
+				switch v := tc.body.(type) {
+				case string:
+					bodyLength = len(v)
+				case []byte:
+					bodyLength = len(v)
+				default:
+					bodyLength = len(fmt.Sprintf("%v", tc.body))
+				}
+				resp, err := client.NewPostRequest(ctx, server.URL+"/noop", tc.body).
+					SetHeader("X-Body-Length", fmt.Sprintf("%d", bodyLength)).
+					WriteBodyTo(&result).
+					Do()
+
+				r.NoError(err)
+				r.NotNil(resp)
+				r.Equal(http.StatusOK, resp.StatusCode)
+				r.Equal(tc.expected, result["received_body"])
+			})
+		}
+	})
+
+	t.Run("Request with NoopBodyUnmarshaler", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/noop-unmarshal":
+				w.Write([]byte("Hello, World!"))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient()
+		ctx := context.Background()
+
+		t.Run("String Result", func(t *testing.T) {
+			var result string
+			resp, err := client.NewGetRequest(ctx, server.URL+"/noop-unmarshal").
+				WriteBodyTo(&result).
+				Do()
+
+			r.NoError(err)
+			r.NotNil(resp)
+			r.Equal(http.StatusOK, resp.StatusCode)
+			r.Equal("Hello, World!", result)
+		})
+
+		t.Run("Byte Slice Result", func(t *testing.T) {
+			var result []byte
+			resp, err := client.NewGetRequest(ctx, server.URL+"/noop-unmarshal").
+				WriteBodyTo(&result).
+				Do()
+
+			r.NoError(err)
+			r.NotNil(resp)
+			r.Equal(http.StatusOK, resp.StatusCode)
+			r.Equal([]byte("Hello, World!"), result)
+		})
+	})
+
+	t.Run("Error Handling - 4xx Status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/not-found":
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`{"error": "Not Found"}`))
+			case "/bad-request":
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(`{"error": "Bad Request"}`))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient()
+		ctx := context.Background()
+
+		testCases := []struct {
+			name       string
+			path       string
+			statusCode int
+		}{
+			{
+				name:       "404 Not Found",
+				path:       "/not-found",
+				statusCode: http.StatusNotFound,
+			},
+			{
+				name:       "400 Bad Request",
+				path:       "/bad-request",
+				statusCode: http.StatusBadRequest,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				resp, err := client.NewGetRequest(ctx, server.URL+tc.path).Do()
+
+				r.Error(err)
+				r.NotNil(resp)
+				r.Equal(tc.statusCode, resp.StatusCode)
+				r.Contains(err.Error(), fmt.Sprintf(":%d", tc.statusCode))
+			})
+		}
+	})
+
+	t.Run("Error Handling - 5xx Status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/internal-error":
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`{"error": "Internal Server Error"}`))
+			case "/service-unavailable":
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte(`{"error": "Service Unavailable"}`))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient()
+		ctx := context.Background()
+
+		testCases := []struct {
+			name       string
+			path       string
+			statusCode int
+		}{
+			{
+				name:       "500 Internal Server Error",
+				path:       "/internal-error",
+				statusCode: http.StatusInternalServerError,
+			},
+			{
+				name:       "503 Service Unavailable",
+				path:       "/service-unavailable",
+				statusCode: http.StatusServiceUnavailable,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				resp, err := client.NewGetRequest(ctx, server.URL+tc.path).Do()
+
+				r.Error(err)
+				r.NotNil(resp)
+				r.Equal(tc.statusCode, resp.StatusCode)
+				r.Contains(err.Error(), fmt.Sprintf(":%d", tc.statusCode))
+			})
+		}
+	})
+
+	t.Run("Request with DumpOnError", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/error":
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(`{"error": "Something went wrong"}`))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient().SetDumpOnError()
+		ctx := context.Background()
+
+		resp, err := client.NewGetRequest(ctx, server.URL+"/error").Do()
+
+		r.Error(err)
+		r.NotNil(resp)
+		r.Equal(http.StatusInternalServerError, resp.StatusCode)
+		r.Contains(err.Error(), ":500")
+	})
+
+	t.Run("Request with Stack Trace", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/error":
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(`{"error": "Bad Request"}`))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient().SetStackTraceEnabled(true)
+		ctx := context.Background()
+
+		resp, err := client.NewGetRequest(ctx, server.URL+"/error").Do()
+
+		r.Error(err)
+		r.NotNil(resp)
+		r.Equal(http.StatusBadRequest, resp.StatusCode)
+		r.Contains(err.Error(), ":400")
+	})
+
+	t.Run("Manual Response Body Handling", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/manual":
+				w.Write([]byte("Manual body handling"))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient()
+		ctx := context.Background()
+
+		resp, err := client.NewGetRequest(ctx, server.URL+"/manual").Do()
+
+		r.NoError(err)
+		r.NotNil(resp)
+		r.Equal(http.StatusOK, resp.StatusCode)
+
+		// Manually read and close the body
+		body, err := json.Marshal(resp.Body)
+		r.NoError(err)
+		resp.Body.Close()
+
+		// Verify body was read correctly
+		r.NotEmpty(body)
+	})
+
+	t.Run("Request with Different HTTP Methods", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/methods":
+				response := map[string]string{
+					"method": r.Method,
+					"status": "success",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(response)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient().SetBodyUnmarshaler(NewJSONBodyUnmarshaler())
+		ctx := context.Background()
+
+		testCases := []struct {
+			name   string
+			method string
+			body   interface{}
+		}{
+			{
+				name:   "GET",
+				method: http.MethodGet,
+				body:   nil,
+			},
+			{
+				name:   "POST",
+				method: http.MethodPost,
+				body:   "test body",
+			},
+			{
+				name:   "PUT",
+				method: http.MethodPut,
+				body:   "test body",
+			},
+			{
+				name:   "PATCH",
+				method: http.MethodPatch,
+				body:   "test body",
+			},
+			{
+				name:   "DELETE",
+				method: http.MethodDelete,
+				body:   nil,
+			},
+			{
+				name:   "OPTIONS",
+				method: http.MethodOptions,
+				body:   nil,
+			},
+			{
+				name:   "HEAD",
+				method: http.MethodHead,
+				body:   nil,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				var result map[string]string
+				var resp *http.Response
+				var err error
+
+				switch tc.method {
+				case http.MethodGet:
+					resp, err = client.NewGetRequest(ctx, server.URL+"/methods").
+						WriteBodyTo(&result).Do()
+				case http.MethodPost:
+					resp, err = client.NewPostRequest(ctx, server.URL+"/methods", tc.body).
+						WriteBodyTo(&result).Do()
+				case http.MethodPut:
+					resp, err = client.NewPutRequest(ctx, server.URL+"/methods", tc.body).
+						WriteBodyTo(&result).Do()
+				case http.MethodPatch:
+					resp, err = client.NewPatchRequest(ctx, server.URL+"/methods", tc.body).
+						WriteBodyTo(&result).Do()
+				case http.MethodDelete:
+					resp, err = client.NewDeleteRequest(ctx, server.URL+"/methods").
+						WriteBodyTo(&result).Do()
+				case http.MethodOptions:
+					resp, err = client.NewOptionsRequest(ctx, server.URL+"/methods").
+						WriteBodyTo(&result).Do()
+				case http.MethodHead:
+					resp, err = client.NewHeadRequest(ctx, server.URL+"/methods").Do()
+				}
+
+				if tc.method == http.MethodHead {
+					// HEAD requests typically don't have a body
+					r.NoError(err)
+					r.NotNil(resp)
+					r.Equal(http.StatusOK, resp.StatusCode)
+				} else {
+					r.NoError(err)
+					r.NotNil(resp)
+					r.Equal(http.StatusOK, resp.StatusCode)
+					r.Equal(tc.method, result["method"])
+					r.Equal("success", result["status"])
+				}
+			})
+		}
+	})
+
+	t.Run("Request with JSON Marshaler/Unmarshaler", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/json":
+				if r.Header.Get("Content-Type") != "application/json" {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
+				var requestBody map[string]interface{}
+				if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
+				response := map[string]interface{}{
+					"received": requestBody,
+					"status":   "success",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(response)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient().
+			SetBodyMarshaler(NewJSONBodyMarshaler()).
+			SetBodyUnmarshaler(NewJSONBodyUnmarshaler())
+
+		ctx := context.Background()
+
+		type TestStruct struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+			Age   int    `json:"age"`
+		}
+
+		requestBody := TestStruct{
+			Name:  "Jane Doe",
+			Email: "jane@example.com",
+			Age:   30,
+		}
+
+		var result map[string]interface{}
+		resp, err := client.NewPostRequest(ctx, server.URL+"/json", requestBody).
+			WriteBodyTo(&result).
+			Do()
+
+		r.NoError(err)
+		r.NotNil(resp)
+		r.Equal(http.StatusOK, resp.StatusCode)
+		r.Equal("success", result["status"])
+
+		received := result["received"].(map[string]interface{})
+		r.Equal("Jane Doe", received["name"])
+		r.Equal("jane@example.com", received["email"])
+		r.Equal(float64(30), received["age"]) // JSON numbers are unmarshaled as float64
+	})
+
+	t.Run("Request with Request-Level Overrides", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/override":
+				response := map[string]string{
+					"client_header":  r.Header.Get("X-Client-Header"),
+					"request_header": r.Header.Get("X-Request-Header"),
+					"content_type":   r.Header.Get("Content-Type"),
+					"accept":         r.Header.Get("Accept"),
+					"status":         "success",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(response)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient().
+			SetHeader("X-Client-Header", "client-value").
+			SetBodyMarshaler(NewJSONBodyMarshaler()).
+			SetBodyUnmarshaler(NewJSONBodyUnmarshaler())
+
+		ctx := context.Background()
+
+		var result string
+		resp, err := client.NewGetRequest(ctx, server.URL+"/override").
+			SetHeader("X-Request-Header", "request-value").
+			SetBodyMarshaler(NewNoopBodyMarshaler()).
+			SetBodyUnmarshaler(NewNoopBodyUnmarshaler()).
+			WriteBodyTo(&result).
+			Do()
+
+		r.NoError(err)
+		r.NotNil(resp)
+		r.Equal(http.StatusOK, resp.StatusCode)
+		r.Contains(result, "client-value")
+		r.Contains(result, "request-value")
+		r.Contains(result, "success")
+	})
+
+	t.Run("Request with Error in Hook", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/hook-error":
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte(`{"status": "success"}`))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		ctx := context.Background()
+
+		// Test request hook error
+		t.Run("Request Hook Error", func(t *testing.T) {
+			resp, err := NewHttpClient().NewGetRequest(ctx, server.URL+"/hook-error").
+				SetOnRequestReady(func(req *http.Request) error {
+					return fmt.Errorf("request hook error")
+				}).
+				Do()
+
+			r.Error(err)
+			r.Nil(resp)
+			r.Contains(err.Error(), "request hook error")
+		})
+
+		// Test response hook error
+		t.Run("Response Hook Error", func(t *testing.T) {
+			resp, err := NewHttpClient().NewGetRequest(ctx, server.URL+"/hook-error").
+				SetOnResponseReady(func(resp *http.Response) error {
+					return fmt.Errorf("response hook error")
+				}).
+				Do()
+
+			r.Error(err)
+			r.NotNil(resp)
+			r.Contains(err.Error(), "response hook error")
+		})
+	})
+
+	t.Run("Request with Missing Body Marshaler", func(t *testing.T) {
+		client := NewHttpClient()
+		// Clear the body marshaler to test the error case
+		client.requestOptions.BodyMarshaler = nil
+		ctx := context.Background()
+
+		resp, err := client.NewPostRequest(ctx, "http://example.com", "body").Do()
+
+		r.Error(err)
+		r.Nil(resp)
+		r.Contains(err.Error(), "body marshaler is not set")
+	})
+
+	t.Run("Request with Missing Body Unmarshaler", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/missing-unmarshaler":
+				w.Write([]byte("test response"))
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		client := NewHttpClient()
+		// Clear the body unmarshaler to test the error case
+		client.requestOptions.BodyUnmarshaler = nil
+		ctx := context.Background()
+
+		var result string
+		resp, err := client.NewGetRequest(ctx, server.URL+"/missing-unmarshaler").
+			WriteBodyTo(&result).
+			Do()
+
+		r.Error(err)
+		r.NotNil(resp)
+		r.Contains(err.Error(), "body unmarshaler is not set")
+	})
+}

--- a/debug.go
+++ b/debug.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 )
 
-//type EnrichedError error
-
 type EnrichedError struct {
 	Err   error
 	Stack string

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/AnotherFullstackDev/httpreqx
 
 go 1.20
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/marshalers.go
+++ b/marshalers.go
@@ -75,7 +75,7 @@ func (m *NoopBodyMarshaler) Marshal(body interface{}, writer io.Writer) error {
 	return err
 }
 
-func (m *NoopBodyMarshaler) OnRequestReady(req *http.Request) error {
+func (m *NoopBodyMarshaler) OnRequestReady(_ *http.Request) error {
 	return nil
 }
 

--- a/marshalers.go
+++ b/marshalers.go
@@ -1,18 +1,24 @@
 package httpreqx
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
+// BodyMarshaler is an interface for marshaling request bodies.
+// Allows to configure the request body according to the marshaling type via the OnRequestReady method.
 type BodyMarshaler interface {
 	Marshal(body interface{}, writer io.Writer) error
 	OnRequestReady(req *http.Request) error
 }
 
+// BodyUnmarshaler is an interface for unmarshalling response bodies.
+// Allows to configure the request body according to the unmarshalling type via the OnRequestReady method.
 type BodyUnmarshaler interface {
 	Unmarshal(result interface{}, reader io.Reader) error
 	OnRequestReady(req *http.Request) error
@@ -37,6 +43,11 @@ func (m *JSONBodyMarshaler) OnRequestReady(req *http.Request) error {
 	return nil
 }
 
+// NewJSONBodyMarshaler creates a BodyMarshaler that marshals the body to JSON format.
+// It automatically sets the Content-Type header to application/json.
+// The body can be any type that is supported by the json.Marshal function.
+// Marshaling is done using the json.NewEncoder function, that uses streaming encoding.
+// A caveat is that a new line is added at the end of the body, which is a requirement for the JSON format (see https://go.dev/src/encoding/json/stream.go, (enc *Encoder) Encode method, line 221).
 func NewJSONBodyMarshaler() BodyMarshaler {
 	return &JSONBodyMarshaler{}
 }
@@ -48,25 +59,30 @@ func (m *NoopBodyMarshaler) Marshal(body interface{}, writer io.Writer) error {
 		return errors.New("body is nil")
 	}
 
-	var bodyBytes []byte
+	var reader io.Reader
 	switch v := body.(type) {
 	case []byte:
-		bodyBytes = v
+		reader = bytes.NewReader(v)
+	case string:
+		reader = strings.NewReader(v)
+	case io.Reader:
+		reader = v
 	default:
-		return errors.New(fmt.Sprintf("unsupported body type: %T", body))
+		return fmt.Errorf("unsupported body type: %T", body)
 	}
 
-	if _, err := writer.Write(bodyBytes); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := io.Copy(writer, reader)
+	return err
 }
 
 func (m *NoopBodyMarshaler) OnRequestReady(req *http.Request) error {
 	return nil
 }
 
+// NewNoopBodyMarshaler creates a BodyMarshaler that does not modify the request body.
+// It allows to create requests by passing the same type as the standard http.NewRequestWithContext accepts, with some additions for convenience.
+// The modifications are:
+// - Automatically converts string to strings.Reader if the body is a string.
 func NewNoopBodyMarshaler() BodyMarshaler {
 	return &NoopBodyMarshaler{}
 }

--- a/request.go
+++ b/request.go
@@ -76,6 +76,7 @@ func (c *HttpClient) NewTraceRequest(ctx context.Context, path string) *Request 
 func (r *Request) WriteBodyTo(result interface{}) *Request {
 	r.unmarshalResultTo = result
 	r.unmarshalResult = true
+
 	return r
 }
 
@@ -138,6 +139,7 @@ func (r *Request) Do() (*http.Response, error) {
 
 	// TODO: consider using sync.Pool to reuse buffers for the request body. Might be beneficial for performance in high-load scenarios.
 	bodyBuffer := &bytes.Buffer{}
+
 	if r.body != nil {
 		bodyMarshaler := r.options.BodyMarshaler
 

--- a/request.go
+++ b/request.go
@@ -91,13 +91,13 @@ func (r *Request) SetBodyUnmarshaler(unmarshaler BodyUnmarshaler) *Request {
 	return r
 }
 
-// SetHeaders sets the headers for the request. This will override any headers set at the client level but only for this request.
+// SetHeaders sets the headers for the request. This will override headers with the same name set at the client level but only for this request.
 func (r *Request) SetHeaders(headers map[string]string) *Request {
 	r.options.SetHeaders(headers)
 	return r
 }
 
-// SetHeader sets a single header for the request. This will override any headers set at the client level but only for this request.
+// SetHeader sets a single header for the request. This will override header with the same name set at the client level but only for this request.
 func (r *Request) SetHeader(key, value string) *Request {
 	r.options.SetHeader(key, value)
 	return r
@@ -119,7 +119,7 @@ func (r *Request) SetOnResponseReady(onResponseReady OnResponseReadyHook) *Reque
 
 // SetDumpOnError configures logging of the request, response and error when an error occurs.
 // http.Request and http.Response bodies will be logged as well, if they are set.
-// original, body passed by the caller code will be logged as well, if it is set.
+// Original body passed by the caller code will be logged as well, if it is set.
 // This method will also enable the StackTraceEnabled option, which will add a stack trace to the error if it occurs.
 func (r *Request) SetDumpOnError() *Request {
 	r.options.SetDumpOnError()
@@ -136,7 +136,8 @@ func (r *Request) SetStackTraceEnabled(enabled bool) *Request {
 func (r *Request) Do() (*http.Response, error) {
 	var beforeRequestHooks []OnRequestReadyHook
 
-	bodyBuffer := bytes.NewBuffer(nil)
+	// TODO: consider using sync.Pool to reuse buffers for the request body. Might be beneficial for performance in high-load scenarios.
+	bodyBuffer := &bytes.Buffer{}
 	if r.body != nil {
 		bodyMarshaler := r.options.BodyMarshaler
 

--- a/request_options.go
+++ b/request_options.go
@@ -44,6 +44,7 @@ func (o *RequestOptions) SetHeaders(headers map[string]string) {
 	if o.Headers == nil {
 		o.Headers = make(map[string]string)
 	}
+
 	for k, v := range headers {
 		o.Headers[k] = v
 	}
@@ -64,7 +65,7 @@ func (o *RequestOptions) SetOnResponseReady(onResponseReady OnResponseReadyHook)
 func (o *RequestOptions) SetDumpOnError() {
 	o.SetStackTraceEnabled(true)
 	o.OnErrorHooks = make([]onErrorHook, 0)
-	o.OnErrorHooks = append(o.OnErrorHooks, func(req *http.Request, resp *http.Response, err error, body interface{}) {
+	o.OnErrorHooks = append(o.OnErrorHooks, func(req *http.Request, resp *http.Response, _ error, body interface{}) {
 		dumpRequest(req)
 		dumpResponse(resp)
 		dumpBody(body)

--- a/unmarshalers.go
+++ b/unmarshalers.go
@@ -57,14 +57,18 @@ func (u *NoopBodyUnmarshaler) Unmarshal(result interface{}, reader io.Reader) er
 		if _, err := io.Copy(buf, reader); err != nil {
 			return err
 		}
+
 		*v = buf.Bytes()
+
 		return nil
 	case *string:
 		buf := &bytes.Buffer{}
 		if _, err := io.Copy(buf, reader); err != nil {
 			return err
 		}
+
 		*v = buf.String()
+
 		return nil
 	default:
 		return fmt.Errorf("unsupported result destination for NoopBodyUnmarshaler: %T", result)
@@ -74,7 +78,7 @@ func (u *NoopBodyUnmarshaler) Unmarshal(result interface{}, reader io.Reader) er
 	return err
 }
 
-func (u *NoopBodyUnmarshaler) OnRequestReady(req *http.Request) error {
+func (u *NoopBodyUnmarshaler) OnRequestReady(_ *http.Request) error {
 	return nil
 }
 

--- a/unmarshalers.go
+++ b/unmarshalers.go
@@ -1,8 +1,10 @@
 package httpreqx
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 )
@@ -26,6 +28,62 @@ func (u *JSONBodyUnmarshaler) OnRequestReady(req *http.Request) error {
 	return nil
 }
 
+// NewJSONBodyUnmarshaler creates a BodyUnmarshaler that unmarshalls the response body as JSON format.
+// It automatically sets the Accept header to application/json.
+// Unmarshalling is done via the json.NewDecoder function, that uses streaming decoding.
 func NewJSONBodyUnmarshaler() BodyUnmarshaler {
 	return &JSONBodyUnmarshaler{}
+}
+
+type NoopBodyUnmarshaler struct{}
+
+func (u *NoopBodyUnmarshaler) Unmarshal(result interface{}, reader io.Reader) error {
+	if reader == nil {
+		return errors.New("reader is nil")
+	}
+
+	if result == nil {
+		return errors.New("result destination is nil")
+	}
+
+	var writer io.Writer
+	switch v := result.(type) {
+	case io.Writer:
+		writer = v
+
+	// Extra handling for common types
+	case *[]byte:
+		buf := &bytes.Buffer{}
+		if _, err := io.Copy(buf, reader); err != nil {
+			return err
+		}
+		*v = buf.Bytes()
+		return nil
+	case *string:
+		buf := &bytes.Buffer{}
+		if _, err := io.Copy(buf, reader); err != nil {
+			return err
+		}
+		*v = buf.String()
+		return nil
+	default:
+		return fmt.Errorf("unsupported result destination for NoopBodyUnmarshaler: %T", result)
+	}
+
+	_, err := io.Copy(writer, reader)
+	return err
+}
+
+func (u *NoopBodyUnmarshaler) OnRequestReady(req *http.Request) error {
+	return nil
+}
+
+// NewNoopBodyUnmarshaler creates a BodyUnmarshaler that does not modify the response body.
+// It simply writes the response body to the destination without any additional processing.
+// Allowed result destinations are:
+// - io.Writer
+// - *[]byte
+// - *string
+func NewNoopBodyUnmarshaler() BodyUnmarshaler {
+	return &NoopBodyUnmarshaler{}
 }

--- a/utils.go
+++ b/utils.go
@@ -14,10 +14,14 @@ func CloneRequestBody(r *http.Request) ([]byte, error) {
 	if r.Body == nil {
 		return nil, nil
 	}
+
 	bodyBytes, err := io.ReadAll(r.Body)
+
 	if err != nil {
 		return nil, err
 	}
+
 	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
 	return bodyBytes, nil
 }


### PR DESCRIPTION
- Changed package name used in the codebase to reflect the public library name;
- Added readme with examples;
- Added MIT license;
- Fixes for request body closing;
- Added NoopUnmarshaler as a default unmarshaller;
- Added tests coverage;